### PR TITLE
Fix global window is not defined problem with Nuxt

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -5,5 +5,6 @@ mix.js('src/index.js', 'dist/collapse-transition.js')
 mix.webpackConfig({
     output: {
         libraryTarget: 'umd',
+        globalObject: 'this',
     }
 })


### PR DESCRIPTION
fix #1 

With this [workaround](https://github.com/webpack/webpack/issues/6642#issuecomment-370222543) so it can be imported directly right now.